### PR TITLE
Add API documentation JSON data

### DIFF
--- a/api-docs/projects.json
+++ b/api-docs/projects.json
@@ -1,0 +1,9 @@
+{
+  "name": "free-todolist",
+  "description": "A full-stack todo list application designed for practice, focusing on improving architectural skills and testing various design patterns (container-presenter, layered ...) in both frontend and backend development.",
+  "version": "1.0.0",
+  "routes": [
+    "category",
+    "todolist"
+  ]
+}

--- a/api-docs/routes/category.json
+++ b/api-docs/routes/category.json
@@ -1,0 +1,270 @@
+{
+  "controllerName": "CategoryController",
+  "basePath": "category",
+  "description": "Category management API endpoints",
+  "tags": [
+    "Category"
+  ],
+  "endpoints": [
+    {
+      "path": "/",
+      "method": "POST",
+      "name": "createCategory",
+      "description": "Create a new category",
+      "request": {
+        "body": {
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "카테고리 제목"
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Created category ID"
+          },
+          "title": {
+            "type": "string",
+            "description": "Created category title"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created category createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Created category updatedAt"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Created category deleted"
+          }
+        },
+        "example": {
+          "id": "98874008-8915-4d53-9239-3913f7ee2089",
+          "title": "Test title",
+          "createdAt": "2025-02-10T13:00:27.440Z",
+          "updatedAt": "2025-02-10T13:00:27.440Z",
+          "deleted": false
+        }
+      }
+    },
+    {
+      "path": "/",
+      "method": "GET",
+      "name": "getCategories",
+      "description": "",
+      "request": {
+        "query": {
+          "properties": {
+            "deleted": {
+              "type": "boolean",
+              "description": "Get all category Based on the query."
+            }
+          }
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Found category ID"
+          },
+          "title": {
+            "type": "string",
+            "description": "Found category title"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Found category createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Found category updatedAt"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Found category deleted"
+          }
+        },
+        "example": [
+          {
+            "id": "16874008-8915-4d53-9239-3913f7ee2089",
+            "title": "Test title",
+            "createdAt": "2025-02-10T13:00:27.440Z",
+            "updatedAt": "2025-02-10T13:00:27.440Z",
+            "deleted": false
+          },
+          {
+            "id": "40874008-8915-4d53-9239-3913f7ee2089",
+            "title": "Test title",
+            "createdAt": "2025-02-10T13:00:27.440Z",
+            "updatedAt": "2025-02-10T13:00:27.440Z",
+            "deleted": false
+          },
+          {
+            "id": "98874008-8915-4d53-9239-3913f7ee2089",
+            "title": "Test title",
+            "createdAt": "2025-02-10T13:00:27.440Z",
+            "updatedAt": "2025-02-10T13:00:27.440Z",
+            "deleted": false
+          }
+        ]
+      }
+    },
+    {
+      "path": ":categoryId",
+      "method": "GET",
+      "name": "getCategoryById",
+      "description": "",
+      "request": {
+        "params": {
+          "properties": {
+            "categoryId": {
+              "type": "string",
+              "description": "Target category Id that you find"
+            }
+          }
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Found category ID"
+          },
+          "title": {
+            "type": "string",
+            "description": "Found category title"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Found category createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Found category updatedAt"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Found category deleted"
+          }
+        },
+        "example": {
+          "id": "16874008-8915-4d53-9239-3913f7ee2089",
+          "title": "Test title",
+          "createdAt": "2025-02-10T13:00:27.440Z",
+          "updatedAt": "2025-02-10T13:00:27.440Z",
+          "deleted": false
+        }
+      }
+    },
+    {
+      "path": ":categoryId",
+      "method": "PATCH",
+      "name": "updateCategory",
+      "description": "Update a category you want",
+      "request": {
+        "params": {
+          "properties": {
+            "categoryId": {
+              "type": "string",
+              "description": "Target category id that you want update"
+            }
+          },
+          "required": [
+            "categoryId"
+          ]
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "category ID"
+          },
+          "title": {
+            "type": "string",
+            "description": "Updated category title"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "category createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Updated category updatedAt"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "category deleted"
+          }
+        },
+        "example": {
+          "id": "98874008-8915-4d53-9239-3913f7ee2089",
+          "title": "Test title",
+          "createdAt": "2025-02-10T13:00:27.440Z",
+          "updatedAt": "2025-02-10T13:00:27.440Z",
+          "deleted": false
+        }
+      }
+    },
+    {
+      "path": "/soft/:categoryId",
+      "method": "DELETE",
+      "name": "softDeleteCategoryById",
+      "description": "Delete a category you want",
+      "request": {
+        "params": {
+          "properties": {
+            "categoryId": {
+              "type": "string",
+              "description": "Target category id that you want delete"
+            }
+          },
+          "required": [
+            "categoryId"
+          ]
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "category ID"
+          },
+          "title": {
+            "type": "string",
+            "description": "category title"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "category createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "category updatedAt"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Updated category deleted"
+          }
+        },
+        "example": {
+          "id": "98874008-8915-4d53-9239-3913f7ee2089",
+          "title": "Test title",
+          "createdAt": "2025-02-10T13:00:27.440Z",
+          "updatedAt": "2025-02-10T13:00:27.440Z",
+          "deleted": true
+        }
+      }
+    }
+  ]
+}

--- a/api-docs/routes/todolist.json
+++ b/api-docs/routes/todolist.json
@@ -1,0 +1,397 @@
+{
+  "controllerName": "TodolistController",
+  "basePath": "todolist",
+  "description": "Todolist management API endpoints",
+  "tags": [
+    "Todolist"
+  ],
+  "endpoints": [
+    {
+      "path": "/",
+      "method": "POST",
+      "name": "createTodolist",
+      "description": "Create a new todolist",
+      "request": {
+        "body": {
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Write title of todolist create you want"
+            },
+            "categoryId": {
+              "type": "string",
+              "description": "The location category ID for which you want to create a todolist"
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Created category ID"
+          },
+          "categoryId": {
+            "type": "string",
+            "description": "The location category ID for which you want to create a todolist"
+          },
+          "title": {
+            "type": "string",
+            "description": "Created todolist title"
+          },
+          "checked": {
+            "type": "boolean",
+            "description": "Check todolist completion status"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created todolist createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Created todolist updatedAt"
+          },
+          "order": {
+            "type": "number",
+            "description": "The order of the generated todolists"
+          }
+        },
+        "example": {
+          "id": "ea2a1198-9b29-4258-9021-409b81f57caf",
+          "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+          "title": "create test todolist",
+          "checked": false,
+          "order": 13,
+          "createdAt": "2025-02-11T09:30:08.938Z",
+          "updatedAt": "2025-02-11T09:30:08.938Z"
+        }
+      }
+    },
+    {
+      "path": "/",
+      "method": "GET",
+      "name": "getTodolists",
+      "description": "",
+      "request": {},
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Created category ID"
+          },
+          "categoryId": {
+            "type": "string",
+            "description": "The location category ID"
+          },
+          "title": {
+            "type": "string",
+            "description": "Created todolist title"
+          },
+          "checked": {
+            "type": "boolean",
+            "description": "Check todolist completion status"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created todolist createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Created todolist updatedAt"
+          },
+          "order": {
+            "type": "number",
+            "description": "The order of the generated todolists"
+          }
+        },
+        "example": [
+          {
+            "id": "ea2a1198-9b29-4258-9021-409b81f57caf",
+            "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+            "title": "create test todolist",
+            "checked": false,
+            "order": 1,
+            "createdAt": "2025-02-11T09:30:08.938Z",
+            "updatedAt": "2025-02-11T09:30:08.938Z"
+          },
+          {
+            "id": "252a1198-9b29-4258-9021-409b81f57caf",
+            "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+            "title": "create test todolist",
+            "checked": false,
+            "order": 2,
+            "createdAt": "2025-02-11T09:30:08.938Z",
+            "updatedAt": "2025-02-11T09:30:08.938Z"
+          },
+          {
+            "id": "132a1198-9b29-4258-9021-409b81f57caf",
+            "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+            "title": "create test todolist",
+            "checked": false,
+            "order": 3,
+            "createdAt": "2025-02-11T09:30:08.938Z",
+            "updatedAt": "2025-02-11T09:30:08.938Z"
+          }
+        ]
+      }
+    },
+    {
+      "path": ":categoryId",
+      "method": "GET",
+      "name": "getTodolistsByCategoryId",
+      "description": "",
+      "request": {
+        "query": {
+          "properties": {
+            "checked": {
+              "type": "boolean",
+              "description": "A status value that distinguishes completed from incomplete todolist"
+            }
+          }
+        },
+        "params": {
+          "properties": {
+            "categoryId": {
+              "type": "string",
+              "description": "The location category's id for which you find todolist's"
+            }
+          }
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Created category ID"
+          },
+          "categoryId": {
+            "type": "string",
+            "description": "The location category ID for which you want to create a todolist"
+          },
+          "title": {
+            "type": "string",
+            "description": "Created todolist title"
+          },
+          "checked": {
+            "type": "boolean",
+            "description": "Check todolist completion status"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created todolist createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Created todolist updatedAt"
+          },
+          "order": {
+            "type": "number",
+            "description": "The order of the generated todolists"
+          }
+        },
+        "example": [
+          {
+            "id": "ea2a1198-9b29-4258-9021-409b81f57caf",
+            "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+            "title": "create test todolist",
+            "checked": false,
+            "order": 1,
+            "createdAt": "2025-02-11T09:30:08.938Z",
+            "updatedAt": "2025-02-11T09:30:08.938Z"
+          },
+          {
+            "id": "252a1198-9b29-4258-9021-409b81f57caf",
+            "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+            "title": "create test todolist",
+            "checked": false,
+            "order": 2,
+            "createdAt": "2025-02-11T09:30:08.938Z",
+            "updatedAt": "2025-02-11T09:30:08.938Z"
+          },
+          {
+            "id": "132a1198-9b29-4258-9021-409b81f57caf",
+            "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+            "title": "create test todolist",
+            "checked": false,
+            "order": 3,
+            "createdAt": "2025-02-11T09:30:08.938Z",
+            "updatedAt": "2025-02-11T09:30:08.938Z"
+          }
+        ]
+      }
+    },
+    {
+      "path": "/dates/:categoryId",
+      "method": "GET",
+      "name": "getTodolistsByDate",
+      "description": "",
+      "request": {
+        "query": {
+          "properties": {
+            "checked": {
+              "type": "boolean",
+              "description": "A status value that distinguishes completed from incomplete todolist"
+            }
+          }
+        },
+        "params": {
+          "properties": {
+            "categoryId": {
+              "type": "string",
+              "description": "The location category's id for which you find todolist's"
+            }
+          }
+        }
+      },
+      "response": {
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Contains a list of todolist that were modified or completed on a specific date."
+          },
+          "total": {
+            "type": "number",
+            "description": "The number of data that fits the date."
+          }
+        },
+        "example": {
+          "data": [
+            {
+              "date": "2025-02-02",
+              "todolists": [
+                {
+                  "id": "535edc91-2d9a-404c-a400-175a8e5b2a08",
+                  "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+                  "title": "changed",
+                  "checked": true,
+                  "order": 12,
+                  "createdAt": "2025-02-02T23:46:46.529Z",
+                  "updatedAt": "2025-02-02T23:46:54.255Z"
+                },
+                {
+                  "id": "c62af2fe-4f20-4ed4-8242-ea4deb243e05",
+                  "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+                  "title": "somethin",
+                  "checked": true,
+                  "order": 11,
+                  "createdAt": "2025-02-02T23:46:27.215Z",
+                  "updatedAt": "2025-02-02T23:46:28.977Z"
+                }
+              ]
+            },
+            {
+              "date": "2025-01-31",
+              "todolists": [
+                {
+                  "id": "2a9441d7-b8c9-4e03-960f-10215801751a",
+                  "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+                  "title": "Wabirubi dupdup!!!",
+                  "checked": true,
+                  "order": 0,
+                  "createdAt": "2025-01-22T03:05:22.323Z",
+                  "updatedAt": "2025-01-31T23:26:47.174Z"
+                }
+              ]
+            }
+          ],
+          "total": 2
+        }
+      }
+    },
+    {
+      "path": "/",
+      "method": "PATCH",
+      "name": "updateTodo",
+      "description": "Update a todolist you want",
+      "request": {
+        "body": {
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Target todolist id that you want update"
+            },
+            "title": {
+              "type": "string",
+              "description": "The title of the todolist you want to update"
+            },
+            "checked": {
+              "type": "boolean",
+              "description": "Update the completion status of the todolist you want to update property"
+            }
+          },
+          "required": [
+            "categoryId"
+          ]
+        }
+      },
+      "response": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "target category ID where placed todolist"
+          },
+          "categoryId": {
+            "type": "string",
+            "description": "The location category ID for which you want to create a todolist"
+          },
+          "title": {
+            "type": "string",
+            "description": "Created todolist title"
+          },
+          "checked": {
+            "type": "boolean",
+            "description": "Check todolist completion status"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Created todolist createdAt"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Created todolist updatedAt"
+          },
+          "order": {
+            "type": "number",
+            "description": "The order of the generated todolists"
+          }
+        },
+        "example": {
+          "id": "d55232cb-c8df-465e-8ea7-ce11e884dc2e",
+          "categoryId": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+          "title": "update title",
+          "checked": true,
+          "order": 2,
+          "createdAt": "2025-01-22T03:04:28.724Z",
+          "updatedAt": "2025-02-11T10:01:42.379Z"
+        }
+      }
+    },
+    {
+      "path": "/order",
+      "method": "PATCH",
+      "name": "updateTodoOrder",
+      "description": "Update a todolist you want",
+      "request": {
+        "body": {
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Target todolist id that you want update"
+            },
+            "order": {
+              "type": "number",
+              "description": "The order number of the todolist you want to update"
+            }
+          },
+          "required": [
+            "categoryId"
+          ]
+        }
+      },
+      "response": {}
+    }
+  ]
+}


### PR DESCRIPTION
1. Add test API documentation json data category, todolist

Project metadata:

* Added `projects.json` to describe the `free-todolist` project, including its name, description, version, and routes.

API endpoint specifications:

* Added `category.json` to define API endpoints for category management, including creating, retrieving, updating, and deleting categories.
* Added `todolist.json` to define API endpoints for todo list management, including creating, retrieving, updating, and deleting todo lists.