### PR TITLE
Add loadApiSchema function to get API schema from json

### DIFF
--- a/app/[controller]/page.tsx
+++ b/app/[controller]/page.tsx
@@ -1,4 +1,7 @@
+import { loadApiSchema } from "@/utils/loadApiSchema";
+
 export default async function Page({ params }: { params: Promise<{ controller: string }> }) {
   const { controller } = await params;
+  const data = await loadApiSchema(controller);
   return <div className="w-full h-screen flex justify-center items-center">Hello {controller}!</div>;
 }

--- a/utils/loadApiSchema.ts
+++ b/utils/loadApiSchema.ts
@@ -1,0 +1,11 @@
+import { Controller } from "@/types";
+import fs from "fs/promises";
+import path from "path";
+
+export async function loadApiSchema(name: string) {
+  const jsonPath = path.join(process.cwd(), "api-docs", "routes", `${name}.json`);
+  const response = await fs.readFile(jsonPath, "utf-8");
+  const data: Controller = JSON.parse(response);
+
+  return data;
+}


### PR DESCRIPTION
1. #8 

Key changes include:

* **Integration of new utility function:**
  * `app/[controller]/page.tsx`: Added a call to `loadApiSchema` to fetch the API schema based on the controller parameter and use it in the component. ([app/[controller]/page.tsxR1-R5](diffhunk://#diff-ed0a515b75d60621c9884c51d2c29d0c939df6ff7b5531dfa54e567c9810c660R1-R5))

* **Creation of utility function:**
  * [`utils/loadApiSchema.ts`](diffhunk://#diff-b08559dff98327834446a5e0cf5f2008c9eb7f5ab6db4ed4fd32efe81284830cR1-R11): Added a new function `loadApiSchema` that reads and parses a JSON file corresponding to the given controller name from the `api-docs/routes` directory.