### PR TITLE
Refactor ControllerButton and EndpointList components

### DIFF
--- a/components/button/ControllerButton.tsx
+++ b/components/button/ControllerButton.tsx
@@ -1,11 +1,14 @@
-import { ButtonHTMLAttributes } from "react";
+import React, { ButtonHTMLAttributes } from "react";
+import { Icon } from "@/components";
 import { NotoSans } from "@/lib/assets";
+import { ICONS_LIST } from "@/lib/constants";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  isOpen: boolean;
   children: React.ReactNode;
 }
 
-export function ControllerButton({ children, ...props }: Props) {
+export function ControllerButton({ isOpen, children, ...props }: Props) {
   return (
     <button
       className={`
@@ -16,7 +19,8 @@ export function ControllerButton({ children, ...props }: Props) {
       `}
       {...props}
     >
-      {children}
+      <div>{children}</div>
+      <Icon icons={isOpen ? ICONS_LIST.ARROW_DROP_DOWN : ICONS_LIST.ARROW_DROP_UP} />
     </button>
   );
 }

--- a/components/layout/sidebar/EndpointList.tsx
+++ b/components/layout/sidebar/EndpointList.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from "react";
 import { useActiveSection, useEndpointData } from "@/contexts";
-import { Icon, EndpointButton, ControllerButton } from "@/components";
-import { ICONS_LIST } from "@/lib/constants";
+import { EndpointButton, ControllerButton } from "@/components";
 
 export function EndpointList() {
   const { endpointData } = useEndpointData();
@@ -25,9 +24,8 @@ export function EndpointList() {
       {endpointData.map((data, index) => {
         return (
           <div key={data.controllerName} className="flex flex-col gap-4">
-            <ControllerButton onClick={() => onClickController(index)}>
-              <div>{data.basePath.toUpperCase()}</div>
-              <Icon icons={activeController.includes(index) ? ICONS_LIST.ARROW_DROP_DOWN : ICONS_LIST.ARROW_DROP_UP} />
+            <ControllerButton isOpen={activeController.includes(index)} onClick={() => onClickController(index)}>
+              {data.basePath.toUpperCase()}
             </ControllerButton>
             {activeController.includes(index) && (
               <div className="flex flex-col gap-4 mb-4">


### PR DESCRIPTION
1. Refactor ControllerButton and EndpointList components
Enhancements to `ControllerButton`:

* [`components/button/ControllerButton.tsx`](diffhunk://#diff-fe445bfd265a2ce3a79db19ca414fa0b3ae6935ea7d6df409342a658711ffceaL1-R11): Introduced a new `isOpen` prop to manage the icon state and updated the component to display an icon based on this prop. [[1]](diffhunk://#diff-fe445bfd265a2ce3a79db19ca414fa0b3ae6935ea7d6df409342a658711ffceaL1-R11) [[2]](diffhunk://#diff-fe445bfd265a2ce3a79db19ca414fa0b3ae6935ea7d6df409342a658711ffceaL19-R23)

Updates to `EndpointList`:

* [`components/layout/sidebar/EndpointList.tsx`](diffhunk://#diff-b7b804babfd1571c617be5d677ed2d8379703b5b64bf0ca06f2de006a2d6bcafL5-R5): Updated the `EndpointList` component to pass the `isOpen` prop to `ControllerButton` based on the active controller state. Removed the redundant `Icon` and `ICONS_LIST` imports. [[1]](diffhunk://#diff-b7b804babfd1571c617be5d677ed2d8379703b5b64bf0ca06f2de006a2d6bcafL5-R5) [[2]](diffhunk://#diff-b7b804babfd1571c617be5d677ed2d8379703b5b64bf0ca06f2de006a2d6bcafL28-R28)