### PR TITLE
Add useState hook and display generated curl command

### DIFF
--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { memo, useEffect } from "react";
+import React, { memo, useEffect, useState } from "react";
 import { Icon, JsonView } from "@/components";
 import { NotoSans } from "@/lib/assets";
 import { ICONS_LIST } from "@/lib/constants";
@@ -15,11 +15,13 @@ interface Props {
 }
 
 function Component({ projectData, controllerData, selected, setSelected }: Props) {
+  const [curlCommand, setCurlCommand] = useState("");
   const styles = selected ? "flex-1" : "flex-0";
+
   useEffect(() => {
     if (!selected) return;
-
-    generateCurlCommand(projectData, controllerData, selected);
+    const generated = generateCurlCommand(projectData, controllerData, selected);
+    setCurlCommand(generated);
   }, [selected]);
 
   return (
@@ -51,7 +53,9 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
             </div>
             <div className="flex flex-col gap-4 mt-4">
               <div className={`text-white text-2 font-300`}>Example Request</div>
-              <div className="w-full h-fit p-8 bg-gray-800 rounded-sm text-white text-1 font-300 whitespace-pre-wrap"></div>
+              <div className="w-full h-fit p-8 bg-gray-800 rounded-sm text-white text-1 font-300 whitespace-pre-wrap">
+                {curlCommand}
+              </div>
             </div>
             <div className="flex flex-col gap-4">
               <div className={`text-white text-2 font-300`}>Example Response</div>

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -4,8 +4,8 @@ import React, { memo, useEffect, useState } from "react";
 import { Icon, JsonView } from "@/components";
 import { NotoSans } from "@/lib/assets";
 import { ICONS_LIST } from "@/lib/constants";
-import { Controller, Endpoint, Project } from "@/lib/types";
-import { generateCurlCommand } from "@/lib/utils/generateCurlCommand";
+import { Controller, DefaultProperty, Endpoint, Project } from "@/lib/types";
+import { processQueryParameters, processRequestBody, processUrlParameters } from "@/lib/utils/generateCurlCommand";
 
 interface Props {
   projectData: Project;
@@ -16,13 +16,41 @@ interface Props {
 
 function Component({ projectData, controllerData, selected, setSelected }: Props) {
   const [curlCommand, setCurlCommand] = useState("");
+  const [bodyProps, setBodyProps] = useState<Record<string, DefaultProperty>>();
   const styles = selected ? "flex-1" : "flex-0";
 
   useEffect(() => {
     if (!selected) return;
-    const generated = generateCurlCommand(projectData, controllerData, selected);
-    setCurlCommand(generated);
+    const url = `${projectData.serverUrl}${controllerData.basePath ? "/" + controllerData.basePath : ""}${
+      selected.path
+    }`;
+    const { body, params, query } = selected.request;
+    const { example } = selected.response;
+
+    let processedUrl = url;
+    let curlCommand = `curl -X ${selected.method} ${processedUrl} \\\n`;
+
+    if (params) {
+      processedUrl = processUrlParameters(processedUrl, params.properties, example);
+    }
+
+    if (query) {
+      processedUrl = processQueryParameters(processedUrl, query.properties, example);
+    }
+
+    if (body) {
+      const requestBody = processRequestBody(body.properties, example);
+      setBodyProps(requestBody);
+      curlCommand += `-H "Content-Type: application/json" \\\n`;
+    }
+
+    setCurlCommand(curlCommand);
   }, [selected]);
+
+  useEffect(() => {
+    const formattedBody = JSON.stringify(bodyProps, null, 2);
+    setCurlCommand(curlCommand + `-d '${formattedBody}'`);
+  }, [bodyProps]);
 
   return (
     <div

--- a/lib/utils/generateCurlCommand.ts
+++ b/lib/utils/generateCurlCommand.ts
@@ -1,37 +1,6 @@
-import { ApiResponse, Controller, DefaultProperty, Endpoint, Project } from "@/lib/types";
+import { ApiResponse, DefaultProperty } from "@/lib/types";
 
-export function generateCurlCommand(project: Project, controller: Controller, endpoint: Endpoint) {
-  const url = `${project.serverUrl}${controller.basePath ? "/" + controller.basePath : ""}${endpoint.path}`;
-  const { body, params, query } = endpoint.request;
-  const { example } = endpoint.response;
-
-  let processedUrl = url;
-
-  if (params) {
-    processedUrl = processUrlParameters(processedUrl, params.properties, example);
-  }
-
-  if (query) {
-    processedUrl = processQueryParameters(processedUrl, query.properties, example);
-  }
-
-  let curlCommand = `curl -X ${endpoint.method} ${processedUrl} \\\n`;
-
-  if (body) {
-    const requestBody = processRequestBody(body.properties, example);
-    const formattedBody = JSON.stringify(requestBody, null, 2);
-    curlCommand += `-H "Content-Type: application/json" \\\n`;
-    curlCommand += `-d '${formattedBody}'`;
-  }
-
-  if (curlCommand.endsWith("\\\n")) {
-    return curlCommand.slice(0, -3);
-  }
-
-  return curlCommand;
-}
-
-function processRequestBody(bodyProps: Record<string, DefaultProperty>, example: ApiResponse["example"]) {
+export function processRequestBody(bodyProps: Record<string, DefaultProperty>, example: ApiResponse["example"]) {
   const requestBody: Record<string, any> = {};
 
   if (!example) {
@@ -60,7 +29,7 @@ function processRequestBody(bodyProps: Record<string, DefaultProperty>, example:
   return requestBody;
 }
 
-function processQueryParameters(
+export function processQueryParameters(
   url: string,
   queryProps: Record<string, DefaultProperty>,
   responseExample?: Record<string, any>
@@ -95,7 +64,7 @@ function processQueryParameters(
   return url;
 }
 
-function processUrlParameters(
+export function processUrlParameters(
   url: string,
   paramsProps: Record<string, DefaultProperty>,
   responseExample: Record<string, any>

--- a/lib/utils/generateCurlCommand.ts
+++ b/lib/utils/generateCurlCommand.ts
@@ -5,7 +5,6 @@ export function generateCurlCommand(project: Project, controller: Controller, en
   const { body, params, query } = endpoint.request;
   const { example } = endpoint.response;
 
-  let curlCommand = `curl -X ${endpoint.method} `;
   let processedUrl = url;
 
   if (params) {
@@ -16,11 +15,20 @@ export function generateCurlCommand(project: Project, controller: Controller, en
     processedUrl = processQueryParameters(processedUrl, query.properties, example);
   }
 
+  let curlCommand = `curl -X ${endpoint.method} ${processedUrl} \\\n`;
+
   if (body) {
     const requestBody = processRequestBody(body.properties, example);
     const formattedBody = JSON.stringify(requestBody, null, 2);
+    curlCommand += `-H "Content-Type: application/json" \\\n`;
     curlCommand += `-d '${formattedBody}'`;
   }
+
+  if (curlCommand.endsWith("\\\n")) {
+    return curlCommand.slice(0, -3);
+  }
+
+  return curlCommand;
 }
 
 function processRequestBody(bodyProps: Record<string, DefaultProperty>, example: ApiResponse["example"]) {


### PR DESCRIPTION
1. Add useState hook and display generated curl command
2. Delete generateCurlCommand utils

### Enhancements to `ExecutePanel` Component:

* Added `useState` hooks for `curlCommand` and `bodyProps` to manage the state of the cURL command and request body properties.
* Implemented logic within the `useEffect` hook to construct the cURL command dynamically based on the selected endpoint's request parameters, query parameters, and request body.
* Displayed the generated cURL command in the "Example Request" section of the UI.

### Refactoring of `generateCurlCommand` Utility Functions:

* Removed the `generateCurlCommand` function and split its logic into three separate functions: `processQueryParameters`, `processRequestBody`, and `processUrlParameters`, which are now exported for use in the `ExecutePanel` component. [[1]](diffhunk://#diff-233904e5c87ae2fe0a63101ddfc4f758c0a950b223f68b788f90bbab7c4d8244L1-R3) [[2]](diffhunk://#diff-233904e5c87ae2fe0a63101ddfc4f758c0a950b223f68b788f90bbab7c4d8244L55-R32) [[3]](diffhunk://#diff-233904e5c87ae2fe0a63101ddfc4f758c0a950b223f68b788f90bbab7c4d8244L90-R67)