### PR TITLE
Refector state liftcycle in ExecutePanel

### DIFF
--- a/components/icon/icon.tsx
+++ b/components/icon/icon.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { ICONS_LIST } from "@/lib/constants";
 
 interface props extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement> {
@@ -5,11 +6,7 @@ interface props extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanEle
   icons: ICONS_LIST;
 }
 
-/**
- * @size Just enter the size you want in px.
- * @icons You can call ICONS_LIST in /constants to select the available icons.
- */
-export function Icon({ size = "20px", icons, className, ...props }: props) {
+function Component({ size = "20px", icons, className, ...props }: props) {
   return (
     <span
       className={`
@@ -25,3 +22,9 @@ export function Icon({ size = "20px", icons, className, ...props }: props) {
     </span>
   );
 }
+
+/**
+ * @size Just enter the size you want in px.
+ * @icons You can call ICONS_LIST in /constants to select the available icons.
+ */
+export const Icon = memo(Component);

--- a/components/layout/execute/CurlCommand.tsx
+++ b/components/layout/execute/CurlCommand.tsx
@@ -1,16 +1,20 @@
-import React from "react";
+import React, { memo } from "react";
 
 interface Props {
   command: string;
+  formattedBody: string | undefined;
 }
 
-export function CurlCommand({ command }: Props) {
+function Component({ command, formattedBody }: Props) {
   return (
     <div className="flex flex-col gap-4 mt-4">
-      <div className={`text-white text-2 font-300`}>Example Request</div>
+      <div className={`text-white text-2 font-400`}>Example Request</div>
       <div className="w-full h-fit p-8 bg-gray-800 rounded-sm text-white text-1 font-300 whitespace-pre-wrap">
         {command}
+        {formattedBody ? `-d '${formattedBody}'` : ""}
       </div>
     </div>
   );
 }
+
+export const CurlCommand = memo(Component);

--- a/components/layout/execute/CurlCommand.tsx
+++ b/components/layout/execute/CurlCommand.tsx
@@ -9,9 +9,8 @@ function Component({ command, formattedBody }: Props) {
   return (
     <div className="flex flex-col gap-4 mt-4">
       <div className={`text-white text-2 font-400`}>Example Request</div>
-      <div className="w-full h-fit p-8 bg-gray-800 rounded-sm text-white text-1 font-300 whitespace-pre-wrap">
-        {command}
-        {formattedBody ? `-d '${formattedBody}'` : ""}
+      <div className="w-full h-fit p-8 bg-gray-800 rounded-sm text-white text-1 font-300 whitespace-pre-wrap break-all">
+        {formattedBody ? `${command}-d '${formattedBody}'` : command.slice(0, -3)}
       </div>
     </div>
   );

--- a/components/layout/execute/ExecuteHeader.tsx
+++ b/components/layout/execute/ExecuteHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { Icon } from "@/components";
 import { ICONS_LIST } from "@/lib/constants";
 
@@ -6,15 +6,15 @@ interface Props {
   onClick: () => void;
 }
 
-export function ExecuteHeader({ onClick }: Props) {
+function Component({ onClick }: Props) {
   return (
     <div className="w-full text-end p-7 pb-0">
       <Icon
         className={`
-                text-gray-100 cursor-pointer select-none
-                hover:text-gray-400
-                active:text-gray-200
-              `}
+          text-gray-100 cursor-pointer select-none
+          hover:text-gray-400
+          active:text-gray-200
+        `}
         size="30px"
         icons={ICONS_LIST.CLOSE}
         onClick={onClick}
@@ -22,3 +22,5 @@ export function ExecuteHeader({ onClick }: Props) {
     </div>
   );
 }
+
+export const ExecuteHeader = memo(Component);

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -3,7 +3,7 @@
 import React, { memo, useEffect, useState } from "react";
 import { CurlCommand, ExecuteHeader, ExecuteResponseExample } from "@/components";
 import { NotoSans } from "@/lib/assets";
-import { Controller, DefaultProperty, Endpoint, Project } from "@/lib/types";
+import { Controller, Endpoint, Project } from "@/lib/types";
 import { processQueryParameters, processRequestBody, processUrlParameters } from "@/lib/utils/generateCurlCommand";
 
 interface Props {
@@ -15,7 +15,7 @@ interface Props {
 
 function Component({ projectData, controllerData, selected, setSelected }: Props) {
   const [curlCommand, setCurlCommand] = useState("");
-  const [bodyProps, setBodyProps] = useState<Record<string, DefaultProperty>>();
+  const [bodyProps, setBodyProps] = useState<Record<string, string>>();
   const styles = selected ? "flex-1" : "flex-0";
 
   useEffect(() => {
@@ -46,11 +46,6 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
     setCurlCommand(curlCommand);
   }, [selected]);
 
-  useEffect(() => {
-    const formattedBody = JSON.stringify(bodyProps, null, 2);
-    setCurlCommand(curlCommand + `-d '${formattedBody}'`);
-  }, [bodyProps]);
-
   return (
     <div
       className={`
@@ -67,7 +62,27 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
               <span>{selected.method}</span>
               <span>/{controllerData.basePath + selected.path}</span>
             </div>
-            <CurlCommand command={curlCommand} />
+            <div className="flex flex-col gap-4">
+              {bodyProps &&
+                Object.entries(bodyProps).map(([key, value]) => {
+                  return (
+                    <div key={key} className="flex flex-col gap-2">
+                      <div className="text-2 text-white">{key}</div>
+                      <input
+                        onChange={(e) => {
+                          const newProps = { ...bodyProps };
+                          newProps[key] = e.currentTarget.value;
+                          setBodyProps(newProps);
+                        }}
+                        className="w-full py-4 px-8 rounded-sm outline-none border-none bg-gray-800 text-1 text-white"
+                        placeholder={value}
+                        type="text"
+                      />
+                    </div>
+                  );
+                })}
+            </div>
+            <CurlCommand command={curlCommand} formattedBody={JSON.stringify(bodyProps, null, 2) || undefined} />
             <ExecuteResponseExample endpoint={selected} />
           </div>
         </div>

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -44,6 +44,10 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
     }
 
     setCurlCommand(curlCommand);
+
+    return () => {
+      setBodyProps(undefined);
+    };
   }, [selected]);
 
   return (
@@ -54,7 +58,7 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
       `}
     >
       {selected && (
-        <div>
+        <>
           <ExecuteHeader onClick={() => setSelected(null)} />
           <div className={`flex flex-col gap-4 pb-8 px-11 ${NotoSans.className}`}>
             <div className="text-5 font-300 text-white">{selected.name}</div>
@@ -85,7 +89,7 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
             <CurlCommand command={curlCommand} formattedBody={JSON.stringify(bodyProps, null, 2) || undefined} />
             <ExecuteResponseExample endpoint={selected} />
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/components/layout/execute/ExecuteResponseExample.tsx
+++ b/components/layout/execute/ExecuteResponseExample.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import { JsonView } from "@/components";
 import { Endpoint } from "@/lib/types";
 
@@ -6,10 +6,10 @@ interface Props {
   endpoint: Endpoint;
 }
 
-export function ExecuteResponseExample({ endpoint }: Props) {
+function Component({ endpoint }: Props) {
   return (
     <div className="flex flex-col gap-4">
-      <div className={`text-white text-2 font-300`}>Example Response</div>
+      <div className={`text-white text-2 font-400`}>Example Response</div>
       <div className="w-full h-fit p-8 bg-gray-800 rounded-sm">
         <JsonView
           src={endpoint.response.example}
@@ -22,3 +22,5 @@ export function ExecuteResponseExample({ endpoint }: Props) {
     </div>
   );
 }
+
+export const ExecuteResponseExample = memo(Component);


### PR DESCRIPTION
1. Refactor component props and styles
2. Refactor ExecutePanel component
3. Refactor Icon component and fix bodyProps bug in ExecutePanel
4. Refactor CurlCommand component to improve readability

Performance improvements:

* [`components/icon/icon.tsx`](diffhunk://#diff-48d9ffa49ee2372cfd42cf67ab34157743603efc1a8c9cef5609c35c83af4a99R1-R9): Wrapped the `Component` function with `memo` and updated the export to use `memo`. [[1]](diffhunk://#diff-48d9ffa49ee2372cfd42cf67ab34157743603efc1a8c9cef5609c35c83af4a99R1-R9) [[2]](diffhunk://#diff-48d9ffa49ee2372cfd42cf67ab34157743603efc1a8c9cef5609c35c83af4a99R25-R30)
* [`components/layout/execute/CurlCommand.tsx`](diffhunk://#diff-af442f548ddf86b9821a76befb5b869d300eb38c48459140705cd75f730fb2beL1-R19): Wrapped the `Component` function with `memo` and updated the export to use `memo`.
* [`components/layout/execute/ExecuteHeader.tsx`](diffhunk://#diff-94e410b83a93111e99c2354a7e69762652b2a5aa1355683d495f6cf953658beeL1-R9): Wrapped the `Component` function with `memo` and updated the export to use `memo`. [[1]](diffhunk://#diff-94e410b83a93111e99c2354a7e69762652b2a5aa1355683d495f6cf953658beeL1-R9) [[2]](diffhunk://#diff-94e410b83a93111e99c2354a7e69762652b2a5aa1355683d495f6cf953658beeR25-R26)
* [`components/layout/execute/ExecuteResponseExample.tsx`](diffhunk://#diff-aecfa448fd8cb6a263b5b03e0c7ecafee9484687faee128d2ce593aab3e8eebbL1-R12): Wrapped the `Component` function with `memo` and updated the export to use `memo`. [[1]](diffhunk://#diff-aecfa448fd8cb6a263b5b03e0c7ecafee9484687faee128d2ce593aab3e8eebbL1-R12) [[2]](diffhunk://#diff-aecfa448fd8cb6a263b5b03e0c7ecafee9484687faee128d2ce593aab3e8eebbR25-R26)

Functional updates:

* [`components/layout/execute/ExecutePanel.tsx`](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L6-R6): Updated the `bodyProps` state type, added logic to handle request body input changes, and updated the `CurlCommand` component to include the formatted request body. [[1]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L6-R6) [[2]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L18-R18) [[3]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L47-R51) [[4]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L62-R92)