### PR TITLE
Add CurlBodyProps component and update ExecutePanel

### DIFF
--- a/api-docs/routes/category.json
+++ b/api-docs/routes/category.json
@@ -2,9 +2,7 @@
   "controllerName": "Category",
   "basePath": "category",
   "description": "Category management API endpoints",
-  "tags": [
-    "Category"
-  ],
+  "tags": ["Category"],
   "endpoints": [
     {
       "path": "",
@@ -75,7 +73,7 @@
       }
     },
     {
-      "path": "/:categoryId",
+      "path": "/:categoryId/post/:postId",
       "method": "GET",
       "name": "Get Category By Id",
       "description": "This endpoint retrieves detailed information about a specific category identified by its unique categoryId.\n  It returns the complete category object including its identifier, title, timestamps, and deletion status.\n  The endpoint will return information even for soft-deleted categories, allowing applications to check deletion status.\n  This endpoint is useful for viewing category details, verifying existence, or checking status before performing operations on the category.",
@@ -83,6 +81,11 @@
         "params": {
           "properties": {
             "categoryId": {
+              "type": "string",
+              "description": "Target category Id that you find",
+              "required": true
+            },
+            "postId": {
               "type": "string",
               "description": "Target category Id that you find",
               "required": true

--- a/components/layout/execute/CurlBodyProps.tsx
+++ b/components/layout/execute/CurlBodyProps.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface Props {
+  bodyProps: Record<string, string> | undefined;
+  setBodyProps: (value: React.SetStateAction<Record<string, string> | undefined>) => void;
+}
+
+export function CurlBodyProps({ bodyProps, setBodyProps }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      {bodyProps &&
+        Object.entries(bodyProps).map(([key, value]) => {
+          return (
+            <div key={key} className="flex flex-col gap-2">
+              <div className="text-2 text-white">{key}</div>
+              <input
+                onChange={(e) => {
+                  const newProps = { ...bodyProps };
+                  newProps[key] = e.currentTarget.value;
+                  setBodyProps(newProps);
+                }}
+                className="w-full py-4 px-8 rounded-sm outline-none border-none bg-gray-800 text-1 text-white"
+                placeholder={value}
+                type="text"
+              />
+            </div>
+          );
+        })}
+    </div>
+  );
+}

--- a/components/layout/execute/CurlCommand.tsx
+++ b/components/layout/execute/CurlCommand.tsx
@@ -1,16 +1,19 @@
 import React, { memo } from "react";
 
 interface Props {
-  command: string;
+  startCommand: string;
+  headers: string;
   formattedBody: string | undefined;
 }
 
-function Component({ command, formattedBody }: Props) {
+function Component({ startCommand, headers, formattedBody }: Props) {
   return (
     <div className="flex flex-col gap-4 mt-4">
       <div className={`text-white text-2 font-400`}>Example Request</div>
       <div className="w-full h-fit p-8 bg-gray-800 rounded-sm text-white text-1 font-300 whitespace-pre-wrap break-all">
-        {formattedBody ? `${command}-d '${formattedBody}'` : command.slice(0, -3)}
+        {startCommand}
+        {headers && ` \\\n${headers}`}
+        {formattedBody && `-d ${formattedBody}`}
       </div>
     </div>
   );

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { memo, useEffect, useState } from "react";
-import { CurlCommand, ExecuteHeader, ExecuteResponseExample } from "@/components";
+import { CurlBodyProps, CurlCommand, ExecuteHeader, ExecuteResponseExample } from "@/components";
 import { NotoSans } from "@/lib/assets";
 import { Controller, Endpoint, Project } from "@/lib/types";
 import { processQueryParameters, processRequestBody, processUrlParameters } from "@/lib/utils/generateCurlCommand";
@@ -14,23 +14,24 @@ interface Props {
 }
 
 function Component({ projectData, controllerData, selected, setSelected }: Props) {
-  const [curlCommand, setCurlCommand] = useState("");
+  const [startCommand, setStartCurlCommand] = useState("");
+  const [headers, setHeaders] = useState("");
   const [bodyProps, setBodyProps] = useState<Record<string, string>>();
+  const [paramsProps, setParamsProps] = useState<Record<string, string>>();
   const styles = selected ? "flex-1" : "flex-0";
 
   useEffect(() => {
     if (!selected) return;
-    const url = `${projectData.serverUrl}${controllerData.basePath ? "/" + controllerData.basePath : ""}${
-      selected.path
-    }`;
+    const url = `${projectData.serverUrl}${controllerData.basePath ? "/" + controllerData.basePath : ""}`;
     const { body, params, query } = selected.request;
     const { example } = selected.response;
 
     let processedUrl = url;
-    let curlCommand = `curl -X ${selected.method} ${processedUrl} \\\n`;
+    let startCommand = `curl -X ${selected.method} ${processedUrl}`;
 
     if (params) {
-      processedUrl = processUrlParameters(processedUrl, params.properties, example);
+      const requestParams = processUrlParameters(params.properties, example);
+      setParamsProps(requestParams);
     }
 
     if (query) {
@@ -40,13 +41,15 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
     if (body) {
       const requestBody = processRequestBody(body.properties, example);
       setBodyProps(requestBody);
-      curlCommand += `-H "Content-Type: application/json" \\\n`;
+      setHeaders((prev) => prev + `-H "Content-Type: application/json" \\\n`);
     }
 
-    setCurlCommand(curlCommand);
+    setStartCurlCommand(startCommand);
 
     return () => {
       setBodyProps(undefined);
+      setParamsProps(undefined);
+      setHeaders("");
     };
   }, [selected]);
 
@@ -66,27 +69,12 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
               <span>{selected.method}</span>
               <span>/{controllerData.basePath + selected.path}</span>
             </div>
-            <div className="flex flex-col gap-4">
-              {bodyProps &&
-                Object.entries(bodyProps).map(([key, value]) => {
-                  return (
-                    <div key={key} className="flex flex-col gap-2">
-                      <div className="text-2 text-white">{key}</div>
-                      <input
-                        onChange={(e) => {
-                          const newProps = { ...bodyProps };
-                          newProps[key] = e.currentTarget.value;
-                          setBodyProps(newProps);
-                        }}
-                        className="w-full py-4 px-8 rounded-sm outline-none border-none bg-gray-800 text-1 text-white"
-                        placeholder={value}
-                        type="text"
-                      />
-                    </div>
-                  );
-                })}
-            </div>
-            <CurlCommand command={curlCommand} formattedBody={JSON.stringify(bodyProps, null, 2) || undefined} />
+            <CurlBodyProps bodyProps={bodyProps} setBodyProps={setBodyProps} />
+            <CurlCommand
+              startCommand={startCommand}
+              headers={headers}
+              formattedBody={JSON.stringify(bodyProps, null, 2) || undefined}
+            />
             <ExecuteResponseExample endpoint={selected} />
           </div>
         </>

--- a/components/layout/execute/index.ts
+++ b/components/layout/execute/index.ts
@@ -1,4 +1,5 @@
+export * from "./CurlBodyProps";
+export * from "./CurlCommand";
 export * from "./ExecutePanel";
 export * from "./ExecuteResponseExample";
-export * from "./CurlCommand";
 export * from "./ExecuteHeader";

--- a/lib/utils/generateCurlCommand.ts
+++ b/lib/utils/generateCurlCommand.ts
@@ -65,27 +65,19 @@ export function processQueryParameters(
 }
 
 export function processUrlParameters(
-  url: string,
   paramsProps: Record<string, DefaultProperty>,
   responseExample: Record<string, any>
 ) {
-  let processedUrl = url;
+  const requestParams: Record<string, any> = {};
 
   for (const paramName in paramsProps) {
-    const paramPattern = new RegExp(`:${paramName}`, "g");
-    let paramValue;
-
     if (responseExample) {
       const choiced = Array.isArray(responseExample) ? responseExample[0] : responseExample;
-      paramValue = choiced[paramName];
+      requestParams[paramName] = choiced[paramName];
     }
 
-    if (!paramValue) {
-      paramValue = `{${paramName}}`;
-    }
-
-    processedUrl = processedUrl.replace(paramPattern, paramValue);
+    requestParams[paramName] = `{${paramName}}`;
   }
 
-  return processedUrl;
+  return requestParams;
 }


### PR DESCRIPTION
1. Add CurlBodyProps component and update ExecutePanel
2. Refactor CurlCommand component to use separate props for startCommand, headers, and formattedBody
3. Refactor category API routes and add postId parameter

### API Documentation Updates:
* [`api-docs/routes/category.json`](diffhunk://#diff-7b17e3a5ebacf67b871ffc6b9b86a9a5f32025793f79aefc5509937c53092c41L78-R76): Updated the endpoint path to include `postId` and added `postId` as a required parameter. [[1]](diffhunk://#diff-7b17e3a5ebacf67b871ffc6b9b86a9a5f32025793f79aefc5509937c53092c41L78-R76) [[2]](diffhunk://#diff-7b17e3a5ebacf67b871ffc6b9b86a9a5f32025793f79aefc5509937c53092c41R87-R91)

### Component Additions:
* [`components/layout/execute/CurlBodyProps.tsx`](diffhunk://#diff-98e5b665932b79ce08e190cdd03d91f3b5fe3a87a5ecb15a9c13264a5a11dc14R1-R31): Added a new `CurlBodyProps` component to handle the body properties of the curl command.

### Component Updates:
* [`components/layout/execute/ExecutePanel.tsx`](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L4-R4): Updated the `ExecutePanel` component to use the new `CurlBodyProps` component, manage headers and parameters, and refactor the curl command generation logic. [[1]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L4-R4) [[2]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L17-R34) [[3]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L43-R52) [[4]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L69-L89)
* [`components/layout/execute/CurlCommand.tsx`](diffhunk://#diff-af442f548ddf86b9821a76befb5b869d300eb38c48459140705cd75f730fb2beL4-R16): Modified the `CurlCommand` component to handle the start command, headers, and formatted body separately.

### Utility Function Updates:
* [`lib/utils/generateCurlCommand.ts`](diffhunk://#diff-233904e5c87ae2fe0a63101ddfc4f758c0a950b223f68b788f90bbab7c4d8244L68-R82): Refactored the `processUrlParameters` function to return request parameters instead of a processed URL.