### PR TITLE
Add formattedParams state and update useEffect to format paramsProps

### DIFF
--- a/components/layout/execute/CurlCommand.tsx
+++ b/components/layout/execute/CurlCommand.tsx
@@ -4,14 +4,16 @@ interface Props {
   startCommand: string;
   headers: string;
   formattedBody: string | undefined;
+  formattedParams: string;
 }
 
-function Component({ startCommand, headers, formattedBody }: Props) {
+function Component({ startCommand, headers, formattedBody, formattedParams }: Props) {
   return (
     <div className="flex flex-col gap-4 mt-4">
       <div className={`text-white text-2 font-400`}>Example Request</div>
       <div className="w-full h-fit p-8 bg-gray-800 rounded-sm text-white text-1 font-300 whitespace-pre-wrap break-all">
         {startCommand}
+        {formattedParams}
         {headers && ` \\\n${headers}`}
         {formattedBody && `-d ${formattedBody}`}
       </div>

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -91,6 +91,7 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
                     <div key={key} className="flex flex-col gap-2">
                       <div className="text-2 text-white">{key}</div>
                       <input
+                        value={paramsProps[key]}
                         onChange={(e) => {
                           const newProps = { ...paramsProps };
                           newProps[key] = e.currentTarget.value;

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -18,6 +18,7 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
   const [headers, setHeaders] = useState("");
   const [bodyProps, setBodyProps] = useState<Record<string, string>>();
   const [paramsProps, setParamsProps] = useState<Record<string, string>>();
+  const [formattedParams, setFormattedParams] = useState("");
   const styles = selected ? "flex-1" : "flex-0";
 
   useEffect(() => {
@@ -50,8 +51,21 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
       setBodyProps(undefined);
       setParamsProps(undefined);
       setHeaders("");
+      setFormattedParams("");
     };
   }, [selected]);
+
+  useEffect(() => {
+    if (!paramsProps) return;
+    const commands = Object.entries(paramsProps).map(([key, value], index) => {
+      if (index === 0) {
+        return `/${value}`;
+      } else {
+        return `/${key}/${value}`;
+      }
+    });
+    setFormattedParams(commands.join(""));
+  }, [paramsProps]);
 
   return (
     <div
@@ -70,10 +84,31 @@ function Component({ projectData, controllerData, selected, setSelected }: Props
               <span>/{controllerData.basePath + selected.path}</span>
             </div>
             <CurlBodyProps bodyProps={bodyProps} setBodyProps={setBodyProps} />
+            <div className="flex flex-col gap-4">
+              {paramsProps &&
+                Object.entries(paramsProps).map(([key, value]) => {
+                  return (
+                    <div key={key} className="flex flex-col gap-2">
+                      <div className="text-2 text-white">{key}</div>
+                      <input
+                        onChange={(e) => {
+                          const newProps = { ...paramsProps };
+                          newProps[key] = e.currentTarget.value;
+                          setParamsProps(newProps);
+                        }}
+                        className="w-full py-4 px-8 rounded-sm outline-none border-none bg-gray-800 text-1 text-white"
+                        placeholder={value}
+                        type="text"
+                      />
+                    </div>
+                  );
+                })}
+            </div>
             <CurlCommand
               startCommand={startCommand}
               headers={headers}
               formattedBody={JSON.stringify(bodyProps, null, 2) || undefined}
+              formattedParams={formattedParams}
             />
             <ExecuteResponseExample endpoint={selected} />
           </div>


### PR DESCRIPTION
1. Add formattedParams state and update useEffect to format paramsProps
2. Add formattedParams to Component props
3. Update input value in ExecutePanel component

### Updates to `CurlCommand` component:

* Added `formattedParams` to the `Props` interface and included it in the component's destructuring assignment.
* Updated the JSX to include `formattedParams` in the curl command display.

### Updates to `ExecutePanel` component:

* Added `formattedParams` state and initialized it with an empty string.
* Reset `formattedParams` when the `selected` state changes.
* Added a new `useEffect` hook to format `paramsProps` into a string suitable for the curl command and update `formattedParams`.
* Updated JSX to include an input field for each parameter in `paramsProps`, allowing users to modify parameter values.
* Passed `formattedParams` to the `CurlCommand` component.