### PR TITLE
Rename request.ts to server.ts in types and Refactor controller and server types to use HttpMethods enum

### DIFF
--- a/lib/types/controller.ts
+++ b/lib/types/controller.ts
@@ -1,3 +1,5 @@
+import { HttpMethods } from "@/lib/types";
+
 export interface Controller {
   controllerName: string;
   basePath: string;
@@ -8,7 +10,7 @@ export interface Controller {
 
 export interface Endpoint {
   path: string;
-  method: string;
+  method: HttpMethods;
   name: string;
   description: string;
   request: ApiRequest;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,3 +1,3 @@
 export * from "./controller";
 export * from "./project";
-export * from "./request";
+export * from "./server";

--- a/lib/types/server.ts
+++ b/lib/types/server.ts
@@ -6,3 +6,5 @@ export interface POSTRequestDefault {
   params: string;
   body: Record<string, string> | undefined;
 }
+
+export type HttpMethods = "POST" | "GET" | "HEAD" | "OPTIONS" | "PUT" | "DELETE" | "PATCH";

--- a/lib/types/server.ts
+++ b/lib/types/server.ts
@@ -1,10 +1,10 @@
+export type HttpMethods = "POST" | "GET" | "HEAD" | "OPTIONS" | "PUT" | "DELETE" | "PATCH";
+
 export interface POSTRequestDefault {
   serverUrl: string;
   endpoint: string;
-  method: string;
+  method: HttpMethods;
   query: string;
   params: string;
   body: Record<string, string> | undefined;
 }
-
-export type HttpMethods = "POST" | "GET" | "HEAD" | "OPTIONS" | "PUT" | "DELETE" | "PATCH";


### PR DESCRIPTION
1. Rename request.ts to server.ts in types 
2. Refactor controller and server types to use HttpMethods enum

Improvements to type safety:

* [`lib/types/controller.ts`](diffhunk://#diff-f65dbb06bed74cb0e39cd74be0c247a9a115603dc90295fca3c1b083200d0739R1-R2): Added a new `HttpMethods` type and updated the `Endpoint` interface to use this new type for the `method` property. [[1]](diffhunk://#diff-f65dbb06bed74cb0e39cd74be0c247a9a115603dc90295fca3c1b083200d0739R1-R2) [[2]](diffhunk://#diff-f65dbb06bed74cb0e39cd74be0c247a9a115603dc90295fca3c1b083200d0739L11-R13)
* [`lib/types/server.ts`](diffhunk://#diff-0a0fad3e8988e406cf024027ba39fa0a697e18fc46972fd27e9c328af39e1d4bR1-R6): Introduced the `HttpMethods` type and updated the `POSTRequestDefault` interface to use this type for the `method` property.

Organizational changes:

* [`lib/types/index.ts`](diffhunk://#diff-489d67aa91e09063da5c34330526703a13b3cdedf7d86426173d0bc62183b6c7L3-R3): Updated exports to reflect the renaming of the `request` file to `server`.
* [`lib/types/server.ts`](diffhunk://#diff-0a0fad3e8988e406cf024027ba39fa0a697e18fc46972fd27e9c328af39e1d4bR1-R6): Renamed from `lib/types/request.ts` to better reflect its contents.