### PR TITLE
Add useApiExecute hook for API execution

### DIFF
--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -29,6 +29,4 @@ export async function POST(req: NextCustomRequest) {
       { status: 500 }
     );
   }
-
-  return NextResponse.json({ data: "hello world!" });
 }

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -2,36 +2,16 @@
 
 import React, { memo } from "react";
 import { useExecuteCommand } from "@/contexts";
-import { useFormattedCommand } from "@/hooks";
+import { useApiExecute, useFormattedCommand } from "@/hooks";
 import { ApiExecuteButton, CurlCommand, CurlProperties, ExecuteHeader, ExecuteResponseExample } from "@/components";
 import { NotoSans } from "@/lib/assets";
-import { POSTRequestDefault } from "@/lib/types";
 
 function Component() {
-  const { projectData, controllerData, selected, bodyProps, setSelected } = useExecuteCommand();
-  const { command, formattedParams, formattedQuerys } = useFormattedCommand();
+  const { controllerData, selected, setSelected } = useExecuteCommand();
+  const { command } = useFormattedCommand();
+  const { responseData, onClickExecute } = useApiExecute();
+
   const styles = selected ? "flex-1" : "flex-0";
-
-  const onClick = async () => {
-    if (!selected) return;
-
-    const defaultBody: POSTRequestDefault = {
-      serverUrl: projectData.serverUrl,
-      endpoint: "/" + controllerData.basePath,
-      method: selected.method,
-      params: formattedParams,
-      query: formattedQuerys,
-      body: bodyProps,
-    };
-
-    const response = await fetch(`http://localhost:3001/api`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(defaultBody),
-    });
-  };
 
   return (
     selected && (
@@ -52,7 +32,7 @@ function Component() {
             <CurlProperties />
             <CurlCommand command={command} />
             <ExecuteResponseExample endpoint={selected} />
-            <ApiExecuteButton onClick={onClick} />
+            <ApiExecuteButton onClick={onClickExecute} />
           </div>
         </div>
       </div>

--- a/components/layout/execute/ExecuteResponse.tsx
+++ b/components/layout/execute/ExecuteResponse.tsx
@@ -1,26 +1,28 @@
 import React, { memo } from "react";
 import { JsonView } from "@/components";
-import { Endpoint } from "@/lib/types";
 
 interface Props {
-  endpoint: Endpoint;
+  title: string;
+  example: Record<string, any> | Record<string, any>[];
 }
 
-function Component({ endpoint }: Props) {
+function Component({ title, example }: Props) {
   return (
     <div className="flex flex-col gap-4">
-      <div className={`text-white text-2 font-400`}>Example Response</div>
+      <div className={`text-white text-2 font-400`}>{title}</div>
       <div className="w-full h-fit p-8 bg-gray-800 rounded-sm">
         <JsonView
-          src={endpoint.response.example}
+          src={example}
           theme={"chalk"}
           style={{ backgroundColor: "transparent" }}
           displayObjectSize={false}
           enableClipboard={false}
+          name={false}
+          collapsed={3}
         />
       </div>
     </div>
   );
 }
 
-export const ExecuteResponseExample = memo(Component);
+export const ExecuteResponse = memo(Component);

--- a/components/layout/execute/index.ts
+++ b/components/layout/execute/index.ts
@@ -3,5 +3,5 @@ export * from "./CurlProperty";
 export * from "./CurlProperties";
 export * from "./CurlPropertyInput";
 export * from "./ExecutePanel";
-export * from "./ExecuteResponseExample";
+export * from "./ExecuteResponse";
 export * from "./ExecuteHeader";

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from "./useApiExecute";
 export * from "./useFormattedCommand";
 export * from "./useIntersectionObserver";
 export * from "./useScroll";

--- a/hooks/useApiExecute.ts
+++ b/hooks/useApiExecute.ts
@@ -1,0 +1,38 @@
+import { useExecuteCommand } from "@/contexts";
+import { useFormattedCommand } from "@/hooks";
+import { POSTRequestDefault } from "@/lib/types";
+import { useState } from "react";
+
+export function useApiExecute() {
+  const { selected, projectData, controllerData, bodyProps } = useExecuteCommand();
+  const { formattedParams, formattedQuerys } = useFormattedCommand();
+  const [responseData, setResponseData] = useState();
+
+  const onClickExecute = async () => {
+    if (!selected) return;
+
+    const defaultBody: POSTRequestDefault = {
+      serverUrl: projectData.serverUrl,
+      endpoint: "/" + controllerData.basePath,
+      method: selected.method,
+      params: formattedParams,
+      query: formattedQuerys,
+      body: bodyProps,
+    };
+
+    const response = await fetch(`http://localhost:3001/api`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(defaultBody),
+    });
+
+    setResponseData(await response.json());
+  };
+
+  return {
+    responseData,
+    onClickExecute,
+  };
+}


### PR DESCRIPTION
1. Add useApiExecute hook for API execution
2. Refactor useApiExecute in ExecutePanel component
3. Rename ExecuteResponseExample to ExecuteResponse and refectoring

### Refactoring and improvements:

* [`components/layout/execute/ExecutePanel.tsx`](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L5-R14): Refactored the component to use the new `useApiExecute` hook for handling API execution logic, simplifying the component by removing the inline fetch logic and related types. [[1]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L5-R14) [[2]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L55-R35)

### Component renaming:

* [`components/layout/execute/ExecuteResponse.tsx`](diffhunk://#diff-04687268ebe4614472d36891e1315ca6ae1c599faabe481f5f10169203f1dc1fL3-R28): Renamed from `ExecuteResponseExample.tsx` and updated the component to accept `title` and `example` props instead of `endpoint`.

### Hook additions:

* [`hooks/useApiExecute.ts`](diffhunk://#diff-cdd7016370aba27afb5d37618123fe0e0e80397d995fe7adf420c38674f604ddR1-R38): Added a new hook `useApiExecute` to encapsulate the API execution logic, including state management for the response data.
* [`hooks/index.ts`](diffhunk://#diff-4573dc8410124fb64982b0c1227ada4ffeead6d6a01f6aa6de96fffeae49b5f6R1): Exported the new `useApiExecute` hook.

### Miscellaneous:

* [`components/layout/execute/index.ts`](diffhunk://#diff-11265b77debc0d2634861d888d750d65b8f9681432b6f9b4e9e3ae0cffb08c80L6-R6): Updated the export statement to reflect the renaming of `ExecuteResponseExample` to `ExecuteResponse`.
* [`app/api/route.ts`](diffhunk://#diff-7f36570f38c57e94863d9a40944b6f6d95de2f83cc13f07f6692ebb30e146f87L32-L33): Removed an unused return statement.