### PR TITLE
Update ExecutePanel component to display actual server response

### DIFF
--- a/components/layout/controller/ResponseExample.tsx
+++ b/components/layout/controller/ResponseExample.tsx
@@ -13,7 +13,7 @@ function Component({ endpoint }: Props) {
     <div>
       <PropertyTitle properties={{}}>RESPONSE</PropertyTitle>
       <div className="pt-8 px-7">
-        <JsonView src={endpoint.response.example} collapsed={1} />
+        <JsonView src={endpoint.response.example} collapsed={1} name={false} />
       </div>
     </div>
   );

--- a/components/layout/execute/ExecutePanel.tsx
+++ b/components/layout/execute/ExecutePanel.tsx
@@ -3,7 +3,7 @@
 import React, { memo } from "react";
 import { useExecuteCommand } from "@/contexts";
 import { useApiExecute, useFormattedCommand } from "@/hooks";
-import { ApiExecuteButton, CurlCommand, CurlProperties, ExecuteHeader, ExecuteResponseExample } from "@/components";
+import { ApiExecuteButton, CurlCommand, CurlProperties, ExecuteHeader, ExecuteResponse } from "@/components";
 import { NotoSans } from "@/lib/assets";
 
 function Component() {
@@ -31,7 +31,11 @@ function Component() {
           <div className="flex flex-col gap-8">
             <CurlProperties />
             <CurlCommand command={command} />
-            <ExecuteResponseExample endpoint={selected} />
+            {responseData ? (
+              <ExecuteResponse title="Actual Server Response" example={responseData} />
+            ) : (
+              <ExecuteResponse title="Example Response" example={selected.response.example} />
+            )}
             <ApiExecuteButton onClick={onClickExecute} />
           </div>
         </div>

--- a/hooks/useApiExecute.ts
+++ b/hooks/useApiExecute.ts
@@ -1,12 +1,12 @@
 import { useExecuteCommand } from "@/contexts";
 import { useFormattedCommand } from "@/hooks";
 import { POSTRequestDefault } from "@/lib/types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function useApiExecute() {
   const { selected, projectData, controllerData, bodyProps } = useExecuteCommand();
   const { formattedParams, formattedQuerys } = useFormattedCommand();
-  const [responseData, setResponseData] = useState();
+  const [responseData, setResponseData] = useState<Record<string, any> | Record<string, any>[] | undefined>();
 
   const onClickExecute = async () => {
     if (!selected) return;
@@ -30,6 +30,12 @@ export function useApiExecute() {
 
     setResponseData(await response.json());
   };
+
+  useEffect(() => {
+    return () => {
+      setResponseData(undefined);
+    };
+  }, [selected]);
 
   return {
     responseData,


### PR DESCRIPTION
1. Update ExecutePanel component to display actual server response
2. Refactor useApiExecute hook to include useEffect

### Component Updates:

* [`components/layout/controller/ResponseExample.tsx`](diffhunk://#diff-9c66d834d3dc3752f5271a40e93b4fc554ba5a6675fd7bab7e3642ba3c282ff0L16-R16): Modified the `JsonView` component to hide the root name in the JSON view by setting the `name` property to `false`.
* [`components/layout/execute/ExecutePanel.tsx`](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L6-R6): Replaced the `ExecuteResponseExample` component with the new `ExecuteResponse` component, which displays either the actual server response or an example response based on the availability of response data. [[1]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L6-R6) [[2]](diffhunk://#diff-8eaca6534ca3118468bb65607c83d395de463cd7d8b229f75c4d0c4711c547d6L34-R38)

### Hook Enhancements:

* [`hooks/useApiExecute.ts`](diffhunk://#diff-cdd7016370aba27afb5d37618123fe0e0e80397d995fe7adf420c38674f604ddL4-R9): Added an `useEffect` hook to reset `responseData` when the selected endpoint changes, ensuring that stale data is not displayed. Also updated the type of `responseData` to be more specific. [[1]](diffhunk://#diff-cdd7016370aba27afb5d37618123fe0e0e80397d995fe7adf420c38674f604ddL4-R9) [[2]](diffhunk://#diff-cdd7016370aba27afb5d37618123fe0e0e80397d995fe7adf420c38674f604ddR34-R39)