### PR TITLE
Refactor useFormattedCommand hook to handle headers and command formatting

### DIFF
--- a/contexts/ExecuteCommandContext.tsx
+++ b/contexts/ExecuteCommandContext.tsx
@@ -14,7 +14,7 @@ interface ExecuteCommandContextType {
   controllerData: Controller;
   selected: Endpoint | null;
   startCommand: string;
-  headers: string;
+  headers: Record<string, any> | undefined;
   bodyProps: Record<string, string> | undefined;
   queryProps: Record<string, string> | undefined;
   paramsProps: Record<string, string> | undefined;
@@ -43,7 +43,7 @@ export function ExecuteCommandProvider({
   setSelected,
 }: ExecuteCommandProviderProps) {
   const [startCommand, setStartCurlCommand] = useState("");
-  const [headers, setHeaders] = useState("");
+  const [headers, setHeaders] = useState<Record<string, any>>();
   const [bodyProps, setBodyProps] = useState<Record<string, string>>();
   const [queryProps, setQueryProps] = useState<Record<string, string>>();
   const [paramsProps, setParamsProps] = useState<Record<string, string>>();
@@ -60,9 +60,7 @@ export function ExecuteCommandProvider({
     const url = getFormattedUrl(selected);
     const { body, params, query, headers } = selected.request;
     const { example } = selected.response;
-
-    let processedUrl = url;
-    let startCommand = `curl -X ${selected.method} ${processedUrl}`;
+    const startCommand = `curl -X ${selected.method} ${url}`;
 
     if (params) {
       const requestParams = processUrlParameters(params.properties, example);
@@ -77,11 +75,16 @@ export function ExecuteCommandProvider({
     if (body) {
       const requestBody = processRequestBody(body.properties, example);
       setBodyProps(requestBody);
-      setHeaders((prev) => prev + `-H "Content-Type: application/json" \\\n`);
+      setHeaders((prev) => {
+        return { ...prev, "Content-Type": "application/json" };
+      });
     }
 
     if (headers) {
       const requestHeader = processHeaders(headers.properties);
+      setHeaders((prev) => {
+        return { ...prev, ...requestHeader };
+      });
     }
 
     setStartCurlCommand(startCommand);
@@ -90,7 +93,7 @@ export function ExecuteCommandProvider({
       setBodyProps(undefined);
       setParamsProps(undefined);
       setQueryProps(undefined);
-      setHeaders("");
+      setHeaders(undefined);
     };
   }, [selected]);
 

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,3 +1,3 @@
 export * from "./endpointsContext";
 export * from "./activeSectionContext";
-export * from "./ExecuteCommandContext";
+export * from "./executeCommandContext";

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./controller";
 export * from "./project";
+export * from "./process";
 export * from "./server";

--- a/lib/types/process.ts
+++ b/lib/types/process.ts
@@ -1,0 +1,5 @@
+export interface HeaderCredential {
+  key: string;
+  type: "Bearer" | "Basic" | "custom";
+  value: string;
+}

--- a/lib/utils/generateCurlCommand.ts
+++ b/lib/utils/generateCurlCommand.ts
@@ -74,7 +74,6 @@ export function processHeaders(headersProps: Record<string, HeaderProperty>) {
         requestHeaders["credentials"].push(credential);
       }
     } else {
-      if (headersProps[headerKey].default === "application/json") continue;
       requestHeaders[headerKey] = headersProps[headerKey].default;
     }
   }


### PR DESCRIPTION
1. Refactor headers to use a Record type
2. Refactor useFormattedCommand hook to handle headers and command formatting
3. Add process.ts to types


### Improvements to `ExecuteCommandContext`:

* [`contexts/ExecuteCommandContext.tsx`](diffhunk://#diff-6c547826281ad7c48ad795e2fe869203eeeba7d420f2071929991b62ace4f3daL17-R17): Changed the `headers` state from a `string` to `Record<string, any> | undefined` and updated the `ExecuteCommandProvider` function to handle headers as an object. This includes setting headers for content type and merging request headers correctly. [[1]](diffhunk://#diff-6c547826281ad7c48ad795e2fe869203eeeba7d420f2071929991b62ace4f3daL17-R17) [[2]](diffhunk://#diff-6c547826281ad7c48ad795e2fe869203eeeba7d420f2071929991b62ace4f3daL46-R46) [[3]](diffhunk://#diff-6c547826281ad7c48ad795e2fe869203eeeba7d420f2071929991b62ace4f3daL63-R63) [[4]](diffhunk://#diff-6c547826281ad7c48ad795e2fe869203eeeba7d420f2071929991b62ace4f3daL80-R87) [[5]](diffhunk://#diff-6c547826281ad7c48ad795e2fe869203eeeba7d420f2071929991b62ace4f3daL93-R96)

### Enhancements to `useFormattedCommand` hook:

* [`hooks/useFormattedCommand.ts`](diffhunk://#diff-2c6889241a4978e4eba9a2f84fa6edd04a75cb56402cc565a7c5fb9ed06d2370R3-R18): Added logic to process and format headers, including handling credentials, and updated the `command` state to include formatted headers. [[1]](diffhunk://#diff-2c6889241a4978e4eba9a2f84fa6edd04a75cb56402cc565a7c5fb9ed06d2370R3-R18) [[2]](diffhunk://#diff-2c6889241a4978e4eba9a2f84fa6edd04a75cb56402cc565a7c5fb9ed06d2370L47-R88)

### Codebase organization:

* [`contexts/index.ts`](diffhunk://#diff-cc28be0fbb39aa239c564d81fab1b8606c883c4d6b3113e468313d4a9b0fe7c2L3-R3): Corrected the export statement to use the proper casing for `ExecuteCommandContext`.
* [`lib/types/index.ts`](diffhunk://#diff-489d67aa91e09063da5c34330526703a13b3cdedf7d86426173d0bc62183b6c7R3): Added an export for the new `process` type.
* [`lib/types/process.ts`](diffhunk://#diff-3d5027706c33fdc9fb34edf6290509f26eddb75f7c50123a922e6194822fb7aaR1-R5): Introduced a new `HeaderCredential` interface to define the structure of header credentials.

### Utility function update:

* [`lib/utils/generateCurlCommand.ts`](diffhunk://#diff-233904e5c87ae2fe0a63101ddfc4f758c0a950b223f68b788f90bbab7c4d8244L77): Removed a conditional check that skipped adding the `application/json` header, ensuring all headers are processed.