### PR TITLE
Add yarn sdks for vscode typescript regulartion

### DIFF
--- a/.yarn/sdks/eslint/lib/config-api.js
+++ b/.yarn/sdks/eslint/lib/config-api.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require eslint/config
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real eslint/config your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/config`));

--- a/.yarn/sdks/eslint/lib/types/config-api.d.ts
+++ b/.yarn/sdks/eslint/lib/types/config-api.d.ts
@@ -5,7 +5,7 @@ const {createRequire, register} = require(`module`);
 const {resolve} = require(`path`);
 const {pathToFileURL} = require(`url`);
 
-const relPnpApiPath = "../../../../../../.pnp.cjs";
+const relPnpApiPath = "../../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -16,7 +16,7 @@ const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
 
 if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
-    // Setup the environment to be able to require eslint/rules
+    // Setup the environment to be able to require eslint/config
     require(absPnpApiPath).setup();
     if (isPnpLoaderEnabled && register) {
       register(pathToFileURL(absPnpLoaderPath));
@@ -28,5 +28,5 @@ const wrapWithUserWrapper = existsSync(absUserWrapperPath)
   ? exports => absRequire(absUserWrapperPath)(exports)
   : exports => exports;
 
-// Defer to the real eslint/rules your application uses
-module.exports = wrapWithUserWrapper(absRequire(`eslint/rules`));
+// Defer to the real eslint/config your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/config`));

--- a/.yarn/sdks/eslint/lib/types/rules.d.ts
+++ b/.yarn/sdks/eslint/lib/types/rules.d.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require eslint/rules
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real eslint/rules your application uses
+module.exports = wrapWithUserWrapper(absRequire(`eslint/rules`));

--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "9.21.0-sdk",
+  "version": "9.23.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs",
   "bin": {
@@ -11,13 +11,17 @@
       "types": "./lib/types/index.d.ts",
       "default": "./lib/api.js"
     },
+    "./config": {
+      "types": "./lib/types/config-api.d.ts",
+      "default": "./lib/config-api.js"
+    },
     "./package.json": "./package.json",
     "./use-at-your-own-risk": {
       "types": "./lib/types/use-at-your-own-risk.d.ts",
       "default": "./lib/unsupported-api.js"
     },
     "./rules": {
-      "types": "./lib/types/rules/index.d.ts"
+      "types": "./lib/types/rules.d.ts"
     },
     "./universal": {
       "types": "./lib/types/universal.d.ts",

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "5.7.3-sdk",
+  "version": "5.8.2-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs",
   "bin": {

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,2 @@
 nodeLinker: pnp
-enableGlobalCache: false
 supportedArchitectures: { os: ["darwin", "linux", "win32"] }


### PR DESCRIPTION
1. Add yarn sdks for vscode typescript regulartion
2. Update TypeScript version to 5.8.2-sdk
3. Update .yarnrc.yml configuration

### SDK Updates:

* [`.yarn/sdks/eslint/package.json`](diffhunk://#diff-2c1e5b28a622505b675a6fe6b2e191bc3e2e457892bf3721a96fe091ba811656L3-R3): Updated ESLint SDK version from `9.21.0-sdk` to `9.23.0-sdk`.
* [`.yarn/sdks/typescript/package.json`](diffhunk://#diff-6bdc4200163dacbcaa63548ee249c5a3d35ac2805c9439d2d27018c50bf7b388L3-R3): Updated TypeScript SDK version from `5.7.3-sdk` to `5.8.2-sdk`.

### Configuration Changes:

* [`.yarn/sdks/eslint/package.json`](diffhunk://#diff-2c1e5b28a622505b675a6fe6b2e191bc3e2e457892bf3721a96fe091ba811656R14-R24): Added new configuration for `./config` to include `types` and `default` paths for `config-api`.
* [`.yarnrc.yml`](diffhunk://#diff-88fbe28c4102501b94961511a0d70ff895bf39970b4d3fc11917794a239117c5L2): Removed the `enableGlobalCache` setting.

### New Script:

* [`.yarn/sdks/eslint/lib/config-api.js`](diffhunk://#diff-45a42a61a6c882b52caf8a126e9584938cb4cc5ad4be03448dc6f60af8589dcfR1-R32): Added a new script to set up the environment for requiring `eslint/config`, including handling PnP (Plug'n'Play) API paths and user wrappers.