### PR TITLE
Update .gitignore and category.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.*
 .yarn/*
+!.yarn/sdks
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases
@@ -39,12 +40,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-
-# yarn berry
-.yarn/*
-!.yarn/cache
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions

--- a/api-docs/routes/category.json
+++ b/api-docs/routes/category.json
@@ -180,12 +180,6 @@
               "credentials": {
                 "type": "Bearer"
               }
-            },
-            "X-API-KEY": {
-              "default": "X-API-KEY",
-              "credentials": {
-                "type": "custom"
-              }
             }
           }
         }


### PR DESCRIPTION
This pull request includes a change to the `api-docs/routes/category.json` file. The change involves removing the `X-API-KEY` authentication method from the API documentation.

* [`api-docs/routes/category.json`](diffhunk://#diff-7b17e3a5ebacf67b871ffc6b9b86a9a5f32025793f79aefc5509937c53092c41L183-L188): Removed the `X-API-KEY` authentication method, which included the default value and custom credentials type.